### PR TITLE
add support for `subpages` (issue #23)

### DIFF
--- a/script/export.js
+++ b/script/export.js
@@ -114,6 +114,7 @@ const parseElementValue = (
       else return value;
 
     case "asset":
+    case "subpages":
     case "modular_content":
     case "multiple_choice":
     case "taxonomy": {
@@ -254,6 +255,7 @@ const getReferenceForObject = (
       }
       break;
 
+    case "subpages":
     case "modular_content":
       // Load cache if it hasn't been loaded yet
       if (!modularCache) {

--- a/script/util.js
+++ b/script/util.js
@@ -64,6 +64,7 @@ const getValueForUpsert = (value, type, codeName, currencyFormat, componentData 
       };
     }
     case "asset":
+    case "subpages":
     case "modular_content":
     case "multiple_choice":
     case "taxonomy": {


### PR DESCRIPTION
Fixes #23 by allowing `subpages` to be imported alongside `modular_content`.

This fix has been tested against demo projects/environments and production too.